### PR TITLE
kube: Expose service with loadbalancer on master

### DIFF
--- a/kubernetes/overlays/master/kustomization.yaml
+++ b/kubernetes/overlays/master/kustomization.yaml
@@ -7,6 +7,7 @@ commonAnnotations:
   note: Deployed via Github Actions
 patchesStrategicMerge:
 - deployment.yaml
+- servicelb-patch.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/kubernetes/overlays/master/servicelb-patch.yaml
+++ b/kubernetes/overlays/master/servicelb-patch.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: features
+  namespace: getkimball
+spec:
+  ports:
+    type: LoadBalancer


### PR DESCRIPTION
So that we can hit the endpoint without needing to exec into a pod or
(setup and connact to a) VPN.