### PR TITLE
swagger: Set operationId

### DIFF
--- a/src/features_handler_v0_features.erl
+++ b/src/features_handler_v0_features.erl
@@ -7,6 +7,7 @@
 trails() ->
     Metadata =    #{
         get => #{
+            operationId => getFeatures,
             tags => ["Features"],
             description => "Gets features and their status",
             produces => ["application/json"],
@@ -19,6 +20,7 @@ trails() ->
             }
         },
         post => #{
+            operationId => setFeature,
             tags => ["Features"],
             description => "Sets a feature status",
             produces => ["application/json"],


### PR DESCRIPTION
operationId is optional but very much needed by client libs. Set it so
libs can pick it up and provide a good interface!