### PR TITLE
k8s: Allow creating configmaps

### DIFF
--- a/kubernetes/base/cluster-role.yaml
+++ b/kubernetes/base/cluster-role.yaml
@@ -18,3 +18,11 @@ rules:
   - list
   - status
   - update
+- apiGroups:
+  - apps
+  - ''
+  resources:
+  - 'configmaps'
+  verbs:
+  # Create can't be restricted by resource name
+  - create


### PR DESCRIPTION
This is otherwise failing on the attempt to create a configmap