### PR TITLE
Tie in specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROJECT_VERSION = 0.1.0
 DEPS = ranch cowboy jsx prometheus prometheus_cowboy hackney trails cowboy_swagger swaggerl kuberlnetes eraven
 BUILD_DEPS = elvis_mk
 LOCAL_DEPS = sasl
-TEST_DEPS = meck
+TEST_DEPS = meck jesse
 TEST_DIR = tests
 
 dep_cowboy = git https://github.com/ninenines/cowboy.git 2.7.0
@@ -14,6 +14,7 @@ dep_cowboy_swagger = hex 2.0.0
 dep_elvis_mk = git https://github.com/inaka/elvis.mk.git 1.0.0
 dep_eraven = git https://github.com/getkimball/eraven.git 2020-05-20
 dep_hackney = hex 1.15.2
+dep_jesse = git https://github.com/for-GET/jesse.git 1.5.5
 dep_jsx = git https://github.com/talentdeficit/jsx.git v2.10.0
 dep_prometheus = git https://github.com/deadtrickster/prometheus.erl.git v4.5.0
 dep_prometheus_cowboy = hex 0.1.8

--- a/src/features_handler_v0_features.erl
+++ b/src/features_handler_v0_features.erl
@@ -50,16 +50,14 @@ features_return_schema() ->
     #{
         type => <<"object">>,
         properties => #{
-           name => #{
-             type => <<"object">>,
-             description => <<"name of feature">>,
-             properties => #{
-               enabled => #{
-                 type => <<"boolean">>,
-                 description => <<"Status of the feature">>
-               }
-             }
-          }
+           features => #{
+              type => <<"object">>,
+              description => <<"Collection of features">>,
+              additionalProperties => #{
+                type => <<"object">>,
+                description => <<"Maps of object to enabled status">>
+              }
+           }
         }
     }.
 

--- a/src/swagger_specified_handler.erl
+++ b/src/swagger_specified_handler.erl
@@ -2,6 +2,10 @@
 -include_lib("kernel/include/logger.hrl").
 -export([upgrade/4]).
 
+-export([method_metadata/2,
+         response_spec/2,
+         response_spec/3]).
+
 
 -callback handle_req(cowboy_req:req(), any()) ->
                 {cowboy_req:req(),
@@ -38,3 +42,6 @@ response_spec(Spec, Code) ->
     CodeSpec = maps:get(Code, Responses),
     CodeSpec.
 
+response_spec(Handler, Method, Code) ->
+    Spec = method_metadata(Handler, Method),
+    response_spec(Spec, Code).

--- a/tests/cowboy_test_helpers.erl
+++ b/tests/cowboy_test_helpers.erl
@@ -4,6 +4,7 @@
          req/0,
          req/3,
          init/3,
+         validate_response_against_spec/2,
          setup/0,
          cleanup/0]).
 
@@ -47,3 +48,7 @@ read_reply({ok, #{streamid:=StreamId}, _Opts}) ->
     after 10 ->
         error
     end.
+
+validate_response_against_spec(Spec, Data) ->
+    {OkOrError, _Resp} = jesse:validate_with_schema(Spec, Data),
+    OkOrError.

--- a/tests/features_handler_v0_features_test.erl
+++ b/tests/features_handler_v0_features_test.erl
@@ -32,16 +32,17 @@ ok_test() ->
 
 create_feature_test() ->
     Name = <<"feature_name">>,
+    Enabled = true,
     Doc = #{
         name => Name,
-        enabled => true
+        enabled => Enabled
     },
 
     ok = meck:new(features_store),
     ok = meck:expect(features_store, set_binary_feature, fun(_, _) -> ok end),
     ok = cowboy_test_helpers:setup(),
     ok = meck:expect(features_store, get_binary_features, fun() ->
-            #{Name => enabled}
+            #{Name => Enabled}
     end),
     PostReq = cowboy_test_helpers:req(post, json, Doc),
     Opts = [],
@@ -55,13 +56,15 @@ create_feature_test() ->
     GetReq = cowboy_test_helpers:req(),
     CowGetResp = cowboy_test_helpers:init(?MUT, GetReq, Opts),
     {response, GetCode, _GetHeaders, GetBody} = cowboy_test_helpers:read_reply(CowGetResp),
+    GetSpec = swagger_specified_handler:response_spec(?MUT, <<"get">>, GetCode),
 
     ?assertEqual(200, GetCode),
     Data = jsx:decode(GetBody, [return_maps]),
+    ok = cowboy_test_helpers:validate_response_against_spec(GetSpec, Data),
 
     ExpectedData = #{
         <<"features">> => #{
-            Name => <<"enabled">>
+            Name => true
     }},
     ?assertEqual(ExpectedData, Data),
 


### PR DESCRIPTION
Tie in the spec to the returned documents so we can use computers to catch inconsistencies, instead of relying on humans. 

The status code is checked against the spec currently, and tests have schema validation. 