### PR TITLE
spec: Remove additionalProperties

### DIFF
--- a/src/features_handler_v0_features.erl
+++ b/src/features_handler_v0_features.erl
@@ -52,11 +52,7 @@ features_return_schema() ->
         properties => #{
            <<"features">> => #{
               type => object,
-              description => <<"Collection of features">>,
-              additionalProperties => #{
-                type => object,
-                description => <<"Maps of feature name to bool enabled status">>
-              }
+              description => <<"Collection of features">>
            }
         }
     }.


### PR DESCRIPTION
This doesn't help much explain what is happening in the API and breaks
the python lib, despite the swagger validator not complaining. Remove
this until it might be needed in the future