### PR TITLE
sentry: Don't set it up if not configured

### DIFF
--- a/src/features_app.erl
+++ b/src/features_app.erl
@@ -93,12 +93,12 @@ setup_sentry() ->
                 #{level => warning,
                   config => #{
                     dsn => ActualDSN
-        }})
+        }}),
+        ok = eraven:set_environment_context(eraven,
+                                       <<"server">>,
+                                       <<"environment">>,
+                                       Version)
     end,
-    ok = eraven:set_environment_context(eraven,
-                                   <<"server">>,
-                                   <<"environment">>,
-                                   Version),
     ok.
 
 setup_file_store_path() ->


### PR DESCRIPTION
This last bit shouldn't be run if Sentry isn't configured