### PR TITLE
quay: Use a better public name

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -144,7 +144,7 @@ jobs:
     - name: Upload to Quay
       env:
         DOCKER_ECR_TAG: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.DOCKER_REPOSITORY }}:${{ needs.build_docker.outputs.docker_tag }}
-        DOCKER_QUAY_TAG: quay.io/${{ github.repository }}:${{ needs.build_docker.outputs.docker_tag }}
+        DOCKER_QUAY_TAG: quay.io/getkimball/api:${{ needs.build_docker.outputs.docker_tag }}
       run: |
         docker tag ${DOCKER_ECR_TAG} ${DOCKER_QUAY_TAG}
         docker push ${DOCKER_QUAY_TAG}


### PR DESCRIPTION
`features` doesn't have context outside our org, just call this the API