### PR TITLE
refactor: Remove an internal serialization format

### DIFF
--- a/src/features_handler_v0_features.erl
+++ b/src/features_handler_v0_features.erl
@@ -104,7 +104,7 @@ handle_req(Req=#{method := <<"POST">>}, Params, Opts) ->
     {Req, Code, #{}, Opts};
 handle_req(Req=#{method := <<"GET">>}, _Params, Opts) ->
     Features = features_store:get_features(),
-    CollapsedFeatures = features:collapse_features_map(Features),
+    CollapsedFeatures = features:collapse_features_to_map(Features),
     ?LOG_DEBUG(#{what=> "collapse map",
                  map => Features}),
     Data = #{<<"features">> => CollapsedFeatures},

--- a/tests/features_handler_v0_features_test.erl
+++ b/tests/features_handler_v0_features_test.erl
@@ -6,7 +6,7 @@
 load() ->
     ok = cowboy_test_helpers:setup(),
     ok = meck:new(features_store),
-    ok = meck:expect(features_store, get_features, fun() -> #{} end),
+    ok = meck:expect(features_store, get_features, fun() -> [] end),
     ok = meck:expect(features_store, set_feature, fun(_, _, _) -> ok end),
     ok.
 
@@ -42,13 +42,7 @@ ok_test() ->
 get_boolean_features_test() ->
     load(),
     FeatureName = <<"feature_foo">>,
-    Features = #{
-        FeatureName => #{
-            boolean => false,
-            rollout_start => undefined,
-            rollout_end => undefined
-    }},
-
+    Features = [test_utils:defaulted_feature_spec(FeatureName, #{boolean=>false})],
     ok = meck:expect(features_store, get_features, fun() -> Features end),
 
     Req = cowboy_test_helpers:req(),
@@ -67,7 +61,7 @@ create_feature_boolean_test() ->
     },
 
     ok = meck:expect(features_store, get_features, fun() ->
-            #{Name => test_utils:defaulted_feature_spec(#{boolean=>Boolean})}
+            [test_utils:defaulted_feature_spec(Name, #{boolean=>Boolean})]
     end),
     PostReq = cowboy_test_helpers:req(post, json, Doc),
     Opts = [],
@@ -101,9 +95,9 @@ create_feature_rollout_test() ->
     },
 
     ok = meck:expect(features_store, get_features, fun() ->
-            #{Name => test_utils:defaulted_feature_spec(
+            [test_utils:defaulted_feature_spec(Name,
                 #{rollout_start => Now,
-                  rollout_end => Later})}
+                  rollout_end => Later})]
     end),
     PostReq = cowboy_test_helpers:req(post, json, Doc),
     PostBody = http_post(PostReq, 204),

--- a/tests/features_store_SUITE.erl
+++ b/tests/features_store_SUITE.erl
@@ -32,8 +32,8 @@ aa_write_read(_Config) ->
                                           {rollout, undefined, undefined}),
     Resp = features_store:get_features(),
 
-    Expected = #{Name => test_utils:defaulted_feature_spec(
-      #{boolean => Boolean})},
+    Expected = [test_utils:defaulted_feature_spec(Name,
+      #{boolean => Boolean})],
     ?assertEqual(Expected, Resp),
 
     exit(Pid, normal),
@@ -67,8 +67,8 @@ ba_external_store_init(_Config) ->
         StoreLibState
     end),
     All = [
-      test_utils:defaulted_feature_spec(#{name=>NameA, boolean=>BooleanA}),
-      replace_keys_with_binary(test_utils:defaulted_feature_spec(#{name=>NameB, boolean=>BooleanB}))
+      test_utils:defaulted_feature_spec(NameA, #{boolean=>BooleanA}),
+      replace_keys_with_binary(test_utils:defaulted_feature_spec(NameB, #{boolean=>BooleanB}))
     ],
     ok = meck:expect(?STORE_LIB, get_all, fun(Ref) ->
         ?assertEqual(StoreLibState, Ref),
@@ -81,8 +81,8 @@ ba_external_store_init(_Config) ->
     meck:wait(?STORE_LIB, get_all, '_', 1000),
     Resp = features_store:get_features(),
 
-    Expected = #{NameA => test_utils:defaulted_feature_spec(#{boolean => BooleanA}),
-                 NameB => test_utils:defaulted_feature_spec(#{boolean => BooleanB})},
+    Expected = [test_utils:defaulted_feature_spec(NameA, #{boolean => BooleanA}),
+                test_utils:defaulted_feature_spec(NameB, #{boolean => BooleanB})],
     ?assertEqual(Expected, Resp),
 
     exit(Pid, normal),
@@ -115,8 +115,7 @@ bb_external_store_store_data(_Config) ->
     ok = features_store:set_feature(Name, {boolean, Boolean},
                                           {rollout, undefined, undefined}),
 
-    Expected = [test_utils:defaulted_feature_spec(#{name=>Name,
-                                                    boolean=>Boolean})],
+    Expected = [test_utils:defaulted_feature_spec(Name, #{boolean=>Boolean})],
     ?assertEqual(Expected, meck:capture(first, ?STORE_LIB, store, '_', 1)),
 
     exit(Pid, normal),
@@ -164,8 +163,8 @@ ca_write_read_rollout(_Config) ->
                                           {rollout, Start, End}),
     Resp = features_store:get_features(),
 
-    Expected = #{Name => test_utils:defaulted_feature_spec(
-      #{rollout_start=>Start, rollout_end=>End})},
+    Expected = [test_utils:defaulted_feature_spec(Name,
+      #{rollout_start=>Start, rollout_end=>End})],
     ?assertEqual(Expected, Resp),
 
     exit(Pid, normal),

--- a/tests/features_test.erl
+++ b/tests/features_test.erl
@@ -5,67 +5,73 @@
 
 collapse_to_boolean_with_boolean_test() ->
     load(),
-
+    Name = <<"example_name">>,
     FalseSpec = test_utils:defaulted_feature_spec(
+        Name,
         #{boolean => false}),
     TrueSpec = test_utils:defaulted_feature_spec(
+        Name,
         #{boolean => true}),
 
-    ?assertEqual(false, ?MUT:collapse_to_boolean(FalseSpec, 0, 0)),
-    ?assertEqual(true, ?MUT:collapse_to_boolean(TrueSpec, 0, 0)),
+    ?assertEqual({Name, false}, ?MUT:collapse_to_boolean(FalseSpec, 0, 0)),
+    ?assertEqual({Name, true}, ?MUT:collapse_to_boolean(TrueSpec, 0, 0)),
 
     unload().
 
 collapse_to_boolean_with_rollout_test() ->
     load(),
+    Name = <<"example_name">>,
     Now = erlang:system_time(seconds),
     Rand = 0.5,
 
     % Before the start of the rollout
     BeforeSpec = test_utils:defaulted_feature_spec(
+        Name,
         #{rollout_start => Now + 10,
           rollout_end => Now + 60}),
 
     % Not yet passed 50% of the rollout
     NotReachedSpec = test_utils:defaulted_feature_spec(
+        Name,
         #{rollout_start => Now -5,
           rollout_end => Now + 10}),
 
     % Passed 50% of the rollout
     ReachedSpec = test_utils:defaulted_feature_spec(
+        Name,
         #{rollout_start => Now - 10,
           rollout_end => Now - 5}),
 
     % After the end of the rollout
     AfterSpec = test_utils:defaulted_feature_spec(
+        Name,
         #{rollout_start => Now - 60,
           rollout_end => Now - 10}),
 
-    ?assertEqual(false, ?MUT:collapse_to_boolean(BeforeSpec, Now, Rand)),
-    ?assertEqual(false, ?MUT:collapse_to_boolean(NotReachedSpec, Now, Rand)),
-    ?assertEqual(true, ?MUT:collapse_to_boolean(ReachedSpec, Now, Rand)),
-    ?assertEqual(true, ?MUT:collapse_to_boolean(AfterSpec, Now, Rand)),
+    ?assertEqual({Name, false}, ?MUT:collapse_to_boolean(BeforeSpec, Now, Rand)),
+    ?assertEqual({Name, false}, ?MUT:collapse_to_boolean(NotReachedSpec, Now, Rand)),
+    ?assertEqual({Name, true}, ?MUT:collapse_to_boolean(ReachedSpec, Now, Rand)),
+    ?assertEqual({Name, true}, ?MUT:collapse_to_boolean(AfterSpec, Now, Rand)),
 
     unload().
 
-collapse_features_map_test() ->
+collapse_features_to_map_test() ->
     load(),
     FalseSpec = test_utils:defaulted_feature_spec(
+        <<"false">>,
         #{boolean => false}),
     TrueSpec = test_utils:defaulted_feature_spec(
+        <<"true">>,
         #{boolean => true}),
 
-    Spec = #{
-        <<"false">> => FalseSpec,
-        <<"true">> => TrueSpec
-    },
+    Spec = [FalseSpec, TrueSpec],
 
     Expected = #{
         <<"false">> => false,
         <<"true">> => true
     },
 
-    Value = ?MUT:collapse_features_map(Spec),
+    Value = ?MUT:collapse_features_to_map(Spec),
 
     ?assertEqual(Expected, Value),
 

--- a/tests/test_utils.erl
+++ b/tests/test_utils.erl
@@ -1,9 +1,10 @@
 -module(test_utils).
 
--export([defaulted_feature_spec/1]).
+-export([defaulted_feature_spec/2]).
 
-defaulted_feature_spec(Spec) ->
+defaulted_feature_spec(Name, Spec) ->
     Default = #{
+      name => Name,
       boolean => false,
       rollout_start => undefined,
       rollout_end => undefined


### PR DESCRIPTION
Remove the internal serialization format of name -> spec. This was used
in 1 location, and didn't benefit from being a map.

In earlier versions this was the returned-to-the-api datastructure, when
there was only booleans. Now that there is more, the name -> spec map
isn't valuable. The whole list is processed anyway.

If there were to be a reason for finding particular features quickly, by
name, a better solution would be to get it from ets directly and process
only the needed values.