### PR TITLE
user flags: Use list instead of tuple

### DIFF
--- a/src/features.erl
+++ b/src/features.erl
@@ -85,7 +85,7 @@ collapse_rollout_progress(Start, End, Now, Rand) ->
 
 collapse_user_with_user_spec(_User, _Specs=[]) ->
     false;
-collapse_user_with_user_spec(User, _Specs=[{Prop, '=', Val}|T]) ->
+collapse_user_with_user_spec(User, _Specs=[[Prop, '=', Val]|T]) ->
     UserVal = maps:get(Prop, User, undefined),
     case UserVal == Val of
         true -> true;

--- a/src/features_handler_v0_features.erl
+++ b/src/features_handler_v0_features.erl
@@ -177,6 +177,6 @@ process_user_spec_input([#{property := Property,
                            comparator := Comparator,
                            value := Value} | T]) ->
     ComparatorAtom = comparator_bin_to_atom(Comparator),
-    [{Property, ComparatorAtom, Value}|process_user_spec_input(T)].
+    [[Property, ComparatorAtom, Value]|process_user_spec_input(T)].
 
 comparator_bin_to_atom(<<"=">>) -> '='.

--- a/src/features_store.erl
+++ b/src/features_store.erl
@@ -324,12 +324,12 @@ build_user_specs(undefined) ->
     [];
 build_user_specs([]) ->
     [];
-build_user_specs([{UserProp, ComparatorAtom='=', Value}|T]) ->
+build_user_specs([[UserProp, ComparatorAtom='=', Value]|T]) ->
     US = #user_spec{prop=UserProp,
                     comparator_atom=ComparatorAtom,
                     value=Value},
     [US | build_user_specs(T)];
-build_user_specs([{_UserProp, _ComparatorAtom, _Value}|_T]) ->
+build_user_specs([[_UserProp, _ComparatorAtom, _Value]|_T]) ->
     throw({invalid_feature, "User flag can only do `=` comparisons"});
 build_user_specs([_H|_T]) ->
     throw({invalid_feature, "Incorrect number of terms for user flag"}).
@@ -340,5 +340,5 @@ userspecs_to_lists([]) ->
 userspecs_to_lists([#user_spec{prop=Prop,
                                comparator_atom=CA,
                                value=Value} |T]) ->
-    Spec = {Prop, CA, Value},
+    Spec = [Prop, CA, Value],
     [Spec|userspecs_to_lists(T)].

--- a/tests/features_handler_v0_features_test.erl
+++ b/tests/features_handler_v0_features_test.erl
@@ -248,7 +248,7 @@ create_feature_user_test() ->
 
     PostReq = cowboy_test_helpers:req(post, json, Doc),
     PostBody = http_post(PostReq, 204),
-    ?assertEqual({user, [{UserProp, '=', Value}]},
+    ?assertEqual({user, [[UserProp, '=', Value]]},
                  meck:capture(first, features_store, set_feature, '_', 4)),
 
     ?assertEqual(#{}, PostBody),
@@ -316,7 +316,7 @@ get_user_features_test() ->
     Comparator = '=',
     Value = <<"42">>,
 
-    UserSpec = [{UserProp, Comparator, Value}],
+    UserSpec = [[UserProp, Comparator, Value]],
 
     UserObj = #{UserProp => Value},
 

--- a/tests/features_store_SUITE.erl
+++ b/tests/features_store_SUITE.erl
@@ -61,7 +61,7 @@ ad_user_spec_write_read(_Config) ->
     {ok, Pid} = ?MUT:start_link(),
     Name = <<"feature">>,
     Boolean = true,
-    UserSpec = [{<<"user_id">>, '=', 42}],
+    UserSpec = [[<<"user_id">>, '=', 42]],
 
     ok = features_store:set_feature(Name, {boolean, Boolean},
                                           {rollout, undefined, undefined},
@@ -118,6 +118,7 @@ bb_external_store_store_data(_Config) ->
 
     Name = <<"feature">>,
     Boolean = true,
+    UserSpecs = [[<<"user_id">>, '=', <<"42">>]],
 
     StoreLibState = make_ref(),
 
@@ -137,9 +138,10 @@ bb_external_store_store_data(_Config) ->
 
     ok = features_store:set_feature(Name, {boolean, Boolean},
                                           {rollout, undefined, undefined},
-                                          {user, []}),
+                                          {user, UserSpecs}),
 
-    Expected = [test_utils:defaulted_feature_spec(Name, #{boolean=>Boolean})],
+    Expected = [test_utils:defaulted_feature_spec(Name, #{boolean=>Boolean,
+                                                          user=>UserSpecs})],
     ?assertEqual(Expected, meck:capture(first, ?STORE_LIB, store, '_', 1)),
 
     exit(Pid, normal),

--- a/tests/features_test.erl
+++ b/tests/features_test.erl
@@ -61,21 +61,21 @@ collapse_to_boolean_with_user_id_test() ->
     TrueSpec = test_utils:defaulted_feature_spec(
         Name,
         #{boolean => false,
-          user => [{<<"user_id">>, '=', 42}]}),
+          user => [[<<"user_id">>, '=', 42]]}),
     FalseSpec = test_utils:defaulted_feature_spec(
         Name,
         #{boolean => false,
-          user => [{<<"user_id">>, '=', 24}]}),
+          user => [[<<"user_id">>, '=', 24]]}),
     LongTrueSpec = test_utils:defaulted_feature_spec(
         Name,
         #{boolean => false,
-          user => [ {<<"user_id">>, '=', 24},
-                   {<<"user_id">>, '=', 42}]}),
+          user => [ [<<"user_id">>, '=', 24],
+                   [<<"user_id">>, '=', 42]]}),
     LongFalseSpec = test_utils:defaulted_feature_spec(
         Name,
         #{boolean => false,
-          user => [ {<<"user_id">>, '=', 1},
-                   {<<"user_id">>, '=', 2}]}),
+          user => [ [<<"user_id">>, '=', 1],
+                   [<<"user_id">>, '=', 2]]}),
 
     User = #{<<"user_id">> => 42},
 


### PR DESCRIPTION
Tuples don't serialize well. These lists are short so I'm not currently
concerned with performance changes in this, but haven't measured.