### PR TITLE
openapi: Set server to /

### DIFF
--- a/src/features_app.erl
+++ b/src/features_app.erl
@@ -47,7 +47,7 @@ setup_trails() ->
     trails:store(Trails),
     Trails.
 
-set_config(Mode) ->
+set_config(_Mode) ->
     setup_sentry(),
     setup_namespace(),
     setup_additional_namespace_config(),
@@ -56,7 +56,7 @@ set_config(Mode) ->
     ok = application:set_env(cowboy_swagger, global_spec,
         #{
           openapi => "3.0.0",
-          servers => [#{url => get_server(Mode)}],
+          servers => [#{url => "/"}],
           info => #{
             title => "Get Kimball API",
             version => <<"0.0.0">>
@@ -124,11 +124,3 @@ get_features_mode() ->
         "api" -> api_server;
         _ -> api_server
     end.
-
-get_server(_Mode=api_server) ->
-    os:getenv("OPENAPI_SERVER", "http://localhost:8080");
-get_server(_Mode=sidecar) ->
-    Host = os:getenv("HOST_IP", "localhost"),
-    Port = os:getenv("HOST_PORT", "8080"),
-    Server = "http://" ++ Host ++ ":" ++ Port,
-    Server.


### PR DESCRIPTION
Server url is required, but can be relative, and doesn't need a full
url, I think