### PR TITLE
ui: Fix missing save message

### DIFF
--- a/svelte_src/FeatureSpec.svelte
+++ b/svelte_src/FeatureSpec.svelte
@@ -36,10 +36,10 @@
             body: JSON.stringify(spec)
         });
         let fulfilledResponse = await response;
-        let responseObj = await fulfilledResponse.json()
         if ( fulfilledResponse.ok) {
             saveAlertVisibile = true;
         } else {
+            let responseObj = await fulfilledResponse.json()
             console.log(responseObj);
             failAlertVisibile = true;
             failAlertMessage = responseObj['error']['what'];


### PR DESCRIPTION
The API doesn't repond with any data, so parsing the JSON fails. Move it
to a place where there should be JSON at the time of parsing