### PR TITLE
analytics: Rename features -> events

### DIFF
--- a/src/features_count_relay.erl
+++ b/src/features_count_relay.erl
@@ -10,23 +10,23 @@
 
 -export([add/2]).
 
-add(FeatureName, Key) when is_binary(FeatureName), is_integer(Key) ->
+add(EventName, Key) when is_binary(EventName), is_integer(Key) ->
     KeyB = list_to_binary(integer_to_list(Key)),
-    add(FeatureName, KeyB);
-add(FeatureName, Key) when is_binary(FeatureName), is_binary(Key) ->
+    add(EventName, KeyB);
+add(EventName, Key) when is_binary(EventName), is_binary(Key) ->
     AnalyticsURL = persistent_term:get({features, analytics_url}),
-    send(AnalyticsURL, FeatureName, Key).
+    send(AnalyticsURL, EventName, Key).
 
-send(undefined, FeatureName, Key) ->
+send(undefined, EventName, Key) ->
     ?LOG_INFO(#{
         what => <<"ANALYTICS_HOST not set">>,
-        feature_name => FeatureName,
+        feature_name => EventName,
         user_id => Key
     }),
     ok;
-send(URL, FeatureName, Key) ->
+send(URL, EventName, Key) ->
     Data = #{
-      <<"feature_name">> => FeatureName,
+      <<"event_name">> => EventName,
       <<"user_id">> => Key
     },
     ReqBody = jsx:encode(Data),

--- a/src/features_handler_v0_analytics.erl
+++ b/src/features_handler_v0_analytics.erl
@@ -72,11 +72,11 @@ analytics_return_schema() ->
 
 analytic_event_input_schema() ->
     #{
-        required => [feature_name, user_id],
+        required => [event_name, user_id],
         properties => #{
-           feature_name => #{
+           event_name => #{
                type => string,
-               description => <<"Name of feature">>
+               description => <<"Name of event">>
            },
            user_id => #{
                type => string,
@@ -107,15 +107,15 @@ handle_req(Req=#{method := <<"GET">>}, _Params, _Body=undefined, _Opts) ->
     {Req, 200, Data, #{}};
 handle_req(Req=#{method := <<"POST">>},
            _Params,
-           _Body=#{feature_name:= FeatureName,
+           _Body=#{event_name:= EventName,
                    user_id:= UserID},
            State=#{analytics_event_mod:=AnalyticsEventMod}) ->
 
     ?LOG_DEBUG(#{what=> "Analytic event",
                  user_id => UserID,
                  mode => AnalyticsEventMod,
-                 feature_name => FeatureName}),
-    AnalyticsEventMod:add(FeatureName, UserID),
+                 event_name => EventName}),
+    AnalyticsEventMod:add(EventName, UserID),
 
     {Req, 204, <<"">>, State};
 handle_req(Req, Params, Body, State) ->

--- a/tests/features_count_relay_test.erl
+++ b/tests/features_count_relay_test.erl
@@ -16,7 +16,7 @@ basic_case_test() ->
     load(),
 
     URL = <<"test_url">>,
-    FeatureName = <<"testFeatureName">>,
+    EventName = <<"testEventName">>,
     UserId = <<"testUserId">>,
 
     ClientRef = make_ref(),
@@ -25,10 +25,10 @@ basic_case_test() ->
     meck:expect(hackney, request, ['_', '_', '_', '_', '_'], {ok, 204, [], ClientRef}),
     meck:expect(hackney, body, [ClientRef], {ok, <<"body">>}),
 
-    ok = ?MUT:add(FeatureName, UserId),
+    ok = ?MUT:add(EventName, UserId),
 
     ExpectedHeaders = [{<<"content-type">>, <<"application/json">>}],
-    ExpectedBody = jsx:encode(#{feature_name => FeatureName,
+    ExpectedBody = jsx:encode(#{event_name => EventName,
                                 user_id => UserId}),
     ExpectedOpts = [{timeout, 1000}],
 
@@ -44,7 +44,7 @@ int_user_test() ->
     load(),
 
     URL = <<"test_url">>,
-    FeatureName = <<"testFeatureName">>,
+    EventName = <<"testEventName">>,
     UserId = 42,
 
     ClientRef = make_ref(),
@@ -53,10 +53,10 @@ int_user_test() ->
     meck:expect(hackney, request, ['_', '_', '_', '_', '_'], {ok, 204, [], ClientRef}),
     meck:expect(hackney, body, [ClientRef], {ok, <<"body">>}),
 
-    ok = ?MUT:add(FeatureName, UserId),
+    ok = ?MUT:add(EventName, UserId),
 
     ExpectedHeaders = [{<<"content-type">>, <<"application/json">>}],
-    ExpectedBody = jsx:encode(#{feature_name => FeatureName,
+    ExpectedBody = jsx:encode(#{event_name => EventName,
                                 user_id => <<"42">>}),
     ExpectedOpts = [{timeout, 1000}],
 
@@ -71,11 +71,11 @@ int_user_test() ->
 no_analytics_url_test() ->
     load(),
 
-    FeatureName = <<"testFeatureName">>,
+    EventName = <<"testEventName">>,
     UserId = 42,
 
     persistent_term:put({features, analytics_url}, undefined),
 
-    ok = ?MUT:add(FeatureName, UserId),
+    ok = ?MUT:add(EventName, UserId),
 
     unload().

--- a/tests/features_handler_v0_analytics_test.erl
+++ b/tests/features_handler_v0_analytics_test.erl
@@ -58,10 +58,10 @@ get_boolean_features_test() ->
 
 save_analytic_event_test() ->
     load(),
-    FeatureName = <<"feature_name">>,
+    EventName = <<"event_name">>,
     UserID = <<"user_id">>,
     Doc = #{
-        feature_name => FeatureName,
+        event_name => EventName,
         user_id => UserID
     },
 
@@ -71,7 +71,7 @@ save_analytic_event_test() ->
 
     % features_count_router:add(Feature, UserId);
 
-    ?assertEqual(FeatureName, meck:capture(first, features_count_router, add, '_', 1)),
+    ?assertEqual(EventName, meck:capture(first, features_count_router, add, '_', 1)),
     ?assertEqual(UserID, meck:capture(first, features_count_router, add, '_', 2)),
 
     unload().


### PR DESCRIPTION
Tracking features is good, but goal "features" seems like a weird
phrase. Really we're tracking events (yay generic words /s). Having a
"goal event" makes more sense. As well as eventually tracking multiple
events in 1 API call. (tracking multiple features seems weird too).