### PR TITLE
analytics: Support fluent-bit format

### DIFF
--- a/src/features_handler_v0_analytics.erl
+++ b/src/features_handler_v0_analytics.erl
@@ -106,6 +106,9 @@ analytic_event_input_schema() ->
                    items => EventSchema
                }
             }
+          },
+          #{type => array,
+            items => EventSchema
           }
         ]
     }.
@@ -124,6 +127,12 @@ handle_req(Req=#{method := <<"GET">>},
                  counts => RenderedCounts}),
     {Req, 200, Data, #{}};
 
+handle_req(Req=#{method := <<"POST">>},
+           Params,
+           _Body=Events,
+           State) when is_list(Events)->
+    Body = #{events => Events},
+    handle_req(Req, Params, Body, State);
 handle_req(Req=#{method := <<"POST">>},
            _Params,
            _Body=#{events:=Events},

--- a/tests/features_handler_v0_analytics_test.erl
+++ b/tests/features_handler_v0_analytics_test.erl
@@ -213,6 +213,30 @@ save_multiple_analytic_events_test() ->
 
     unload().
 
+save_list_multiple_analytic_events_test() ->
+    load(),
+    EventName = <<"event_name">>,
+    UserID = <<"user_id">>,
+    Doc = [
+          #{event_name => EventName, user_id => UserID},
+          #{event_name => EventName, user_id => UserID, ensure_goal => false},
+          #{event_name => EventName, user_id => UserID, ensure_goal => true}
+    ],
+
+    PostReq = ?CTH:req(post, json, Doc),
+
+    ?CTH:http_post(?MUT, #{analytics_event_mod=>features_count_router}, PostReq, 204, no_body),
+
+    Expected = [
+      {EventName, UserID, #{ensure_goal => false}},
+      {EventName, UserID, #{ensure_goal => false}},
+      {EventName, UserID, #{ensure_goal => true}}
+    ],
+
+    ?assertEqual(1, meck:num_calls(features_count_router, add, [Expected])),
+
+    unload().
+
 invalid_combination_of_single_and_multiple_events_test() ->
     load(),
     EventName = <<"event_name">>,


### PR DESCRIPTION
Which is a list of events, not a more complicated structure of the other
list API