### PR TITLE
store_lib: b64 encode data

### DIFF
--- a/src/features_store_lib_configmap.erl
+++ b/src/features_store_lib_configmap.erl
@@ -81,7 +81,8 @@ get_configmap(#state{api=API}, NS, Name) ->
 
 
 data_from_configmap_doc(#{<<"data">> := #{<<"data">> := Data}}) ->
-    erlang:binary_to_term(Data).
+    B64Decoded = base64:decode(Data),
+    erlang:binary_to_term(B64Decoded).
 
 create_configmap(#state{api=API}, NS, Name, Doc) ->
     Fields = configmap_request_fields(NS, Name, Doc),
@@ -122,7 +123,7 @@ write_configmap(State=#state{}, NS, Name, Data) ->
 
 
 configmap(Name, Data) ->
-    Serialized = erlang:term_to_binary(Data),
+    Serialized = base64:encode(erlang:term_to_binary(Data)),
     #{<<"apiVersion">> => <<"v1">>,
       <<"kind">> => <<"ConfigMap">>,
       <<"metadata">> => #{

--- a/src/features_store_lib_file.erl
+++ b/src/features_store_lib_file.erl
@@ -21,7 +21,8 @@ init(Name) ->
 
 get_all(State=#state{path=Path}) ->
     ReadFile = file:read_file(Path),
-    DataBin = handle_file(ReadFile, Path),
+    B64Bin = handle_file(ReadFile, Path),
+    DataBin = base64:decode(B64Bin),
     Data = erlang:binary_to_term(DataBin),
 
     {Data, State}.

--- a/tests/features_store_lib_file_test.erl
+++ b/tests/features_store_lib_file_test.erl
@@ -25,7 +25,7 @@ read_test() ->
     ok = meck:expect(application, get_env, [features, file_store_path], {ok, RootPath}),
 
     Data = [#{<<"name">>=><<"name">>, <<"status">>=><<"status">> }],
-    DataBin = erlang:term_to_binary(Data),
+    DataBin = base64:encode(erlang:term_to_binary(Data)),
     ok = meck:expect(file, read_file, ['_'], {ok, DataBin}),
 
     % API = make_ref(),
@@ -46,7 +46,7 @@ store_test() ->
     ok = meck:expect(application, get_env, [features, file_store_path], {ok, []}),
 
     Data = [#{<<"name">>=><<"name">>, <<"status">>=><<"status">> }],
-    DataBin = erlang:term_to_binary(Data),
+    DataBin = base64:encode(erlang:term_to_binary(Data)),
     ok = meck:expect(file, read_file, ['_'], {ok, DataBin}),
 
     % API = make_ref(),


### PR DESCRIPTION
b64 encode the data so the yaml-ness of the configmap doesn't balk at
bytes that may cause problems