### PR TITLE
features_store: Write to store after starting

### DIFF
--- a/src/features_store.erl
+++ b/src/features_store.erl
@@ -156,12 +156,14 @@ handle_cast(load_from_store, State=#state{refresh_interval=RefreshInterval,
                                           store_lib_state=StoreLibState}) ->
 
     {Data, NewStoreLibState} = features_store_lib:get(StoreLibState),
+    LoadedState = State#state{store_lib_state=NewStoreLibState},
     AllFeatures = maps:get(feature_maps, Data, []),
     store_features(AllFeatures),
 
     trigger_refresh_get(RefreshInterval),
+    {_StoreResp, ReadyState} = store_in_storelib(LoadedState),
 
-    {noreply, State#state{store_lib_state=NewStoreLibState}};
+    {noreply, ReadyState};
 handle_cast(_Msg, State) ->
     {noreply, State}.
 

--- a/tests/features_store_SUITE.erl
+++ b/tests/features_store_SUITE.erl
@@ -78,6 +78,9 @@ aa_write_read(Config) ->
                                           {user, undefined}),
     Resp = features_store:get_features(),
 
+    ExpectedStore = #{feature_maps => []},
+    ?assertEqual(ExpectedStore, meck:capture(first, features_store_lib, store, '_', 1)),
+
     Expected = [test_utils:defaulted_feature_spec(Name,
       #{boolean => Boolean})],
     ?assertEqual(Expected, Resp),
@@ -199,7 +202,7 @@ bb_external_store_store_data(Config) ->
                                                              user=>UserSpecs})]
     },
 
-    ?assertEqual(Expected, meck:capture(first, features_store_lib, store, '_', 1)),
+    ?assertEqual(Expected, meck:capture(2, features_store_lib, store, '_', 1)),
 
     Config.
 


### PR DESCRIPTION
To handle the case where there is no daemonset configmap written yet.
This is a bit messy in that the write for the DS is tied to the general
storing of things, but this is typically not a billable API call so
shouldn't add any cost to do this write.