### PR TITLE
Storage Path Prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ make live-js
 * `S3_BUCKET` - AWS S3 Bucket to use for storage
 * `GCS_BUCKET` - Google Cloud Storage Bucket to use for storage
 * `GOOGLE_APPLICATION_CREDENTIALS` - Path to a JSON Service Account Key
-
+* `STORAGE_PATH_PREFIX` - Path prefix to use when storing files in S3/GCS. Defaults to the installation namespace.
 
 ## Releasing
 

--- a/src/features_app.erl
+++ b/src/features_app.erl
@@ -68,12 +68,13 @@ setup_trails() ->
 set_config(Mode) ->
     setup_sentry(),
     Namespace = setup_namespace(),
+    StoragePathPrefix = os:getenv("STORAGE_PATH_PREFIX", Namespace),
     setup_additional_namespace_config(),
     setup_file_store_path(),
     setup_analytics_url(),
     setup_analytics_event_mod(Mode),
-    setup_s3(Namespace),
-    setup_gcs(Namespace),
+    setup_s3(StoragePathPrefix),
+    setup_gcs(StoragePathPrefix),
 
     ok = application:set_env(trails, api_root, "/"),
     ok = application:set_env(features, mode, Mode),


### PR DESCRIPTION
Add configuration for a prefix when storing files in S3/GCS. This can
help with the case where multiple installations use the same bucket, but
all use the same namespace