### PR TITLE
Centrally manage counter persistence triggers

### DIFF
--- a/src/features_count_router.erl
+++ b/src/features_count_router.erl
@@ -27,6 +27,7 @@
          add/3,
          add_goal/1,
          counts/0,
+         counter_pids/0,
          goals/0,
          register_counter/2]).
 
@@ -111,6 +112,12 @@ counts() ->
         [M | Acc0]
     end,
     ets:foldl(CountFun, [], ?COUNTER_REGISTRY).
+
+counter_pids() ->
+    PidFun = fun(#counter_registration{pid=Pid}, Acc0) ->
+        [Pid | Acc0]
+    end,
+    ets:foldl(PidFun, [], ?COUNTER_REGISTRY).
 
 
 %%%===================================================================

--- a/src/features_counter.erl
+++ b/src/features_counter.erl
@@ -87,7 +87,6 @@ init([StoreLib, Name]) ->
     StoreLibState = features_store_lib:init(StoreLib, {"counter", Name}),
     gen_server:cast(self(), load_or_init),
     register_name(Name),
-    {ok, _TRef} = timer:apply_interval(15000, ?MODULE, persist, [self()]),
     {ok, #state{name=Name,
                 store_lib_state=StoreLibState,
                 bloom=undefined}}.

--- a/src/features_counter_persist_manager.erl
+++ b/src/features_counter_persist_manager.erl
@@ -1,0 +1,139 @@
+%%%-------------------------------------------------------------------
+%%% @copyright 2020 Get Kimball Inc.
+%%% @doc
+%%%
+%%% @end
+%%%-------------------------------------------------------------------
+
+-module(features_counter_persist_manager).
+-include_lib("kernel/include/logger.hrl").
+
+-behaviour(gen_server).
+
+%% API functions
+-export([start_link/0,
+         persist/0]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+
+-record(state, {}).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the server
+%%
+%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
+%% @end
+%%--------------------------------------------------------------------
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+persist() ->
+    gen_server:cast(?MODULE, persist).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Initializes the server
+%%
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%% @end
+%%--------------------------------------------------------------------
+init([]) ->
+    {ok, _TRef} = timer:apply_interval(60000, ?MODULE, persist, []),
+    {ok, #state{}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling call messages
+%%
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling cast messages
+%%
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_cast(persist, State) ->
+    ?LOG_DEBUG(#{what=>"Start persist round"}),
+    CounterPids = features_count_router:counter_pids(),
+    lists:foreach(fun features_counter:persist/1, CounterPids),
+    ?LOG_DEBUG(#{what=>"Finished persist round"}),
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling all non call/cast messages
+%%
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%%
+%% @spec terminate(Reason, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, _State) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/src/features_counter_sup.erl
+++ b/src/features_counter_sup.erl
@@ -12,7 +12,9 @@ init([StoreLib]) ->
     ?LOG_INFO(#{what=><<"Counter Supervisor starting">>}),
     Procs = [
         #{id    => features_count_router,
-          start => {features_count_router, start_link, [StoreLib]}}
+          start => {features_count_router, start_link, [StoreLib]}},
+        #{id    => features_counter_persist_manager,
+          start => {features_counter_persist_manager, start_link, []}}
     ],
     Flags = #{strategy => rest_for_one,
               intensity => 0,

--- a/tests/features_count_router_SUITE.erl
+++ b/tests/features_count_router_SUITE.erl
@@ -22,6 +22,7 @@ groups() -> [{test_count, [
                 ag_test_counter_registration_race,
                 ah_test_multiple_counts_added_at_once,
                 ba_test_counter_counts,
+                bb_test_counter_pids,
                 ca_test_start_with_existing_counters,
                 cb_test_counter_registration_persists,
                 da_test_new_goal,
@@ -244,6 +245,18 @@ ba_test_counter_counts(Config) ->
     ?assertEqual([counts(#{name => Feature, count => Num})], Counts),
     Config.
 
+bb_test_counter_pids(Config) ->
+    Feature = <<"feature_name">>,
+    Pid = self(),
+
+    ?MUT:register_counter(Feature, Pid),
+
+    ?MUT:goals(), % Run to synchronize/handle all messages
+
+    Pids = ?MUT:counter_pids(),
+
+    ?assertEqual([Pid], Pids),
+    Config.
 
 ca_test_start_with_existing_counters(Config) ->
     StoreLibState = ?config(store_lib_state, Config),

--- a/tests/features_counter_SUITE.erl
+++ b/tests/features_counter_SUITE.erl
@@ -34,9 +34,6 @@ init_meck(Config) ->
     meck:new(features_count_router),
     meck:expect(features_count_router, register_counter, ['_', '_'], ok),
 
-    meck:new(timer, [unstick]),
-    meck:expect(timer, apply_interval, ['_', '_', '_', '_'], {ok, tref}),
-
     StoreLibState = {store_lib_state, make_ref()},
     meck:new(features_store_lib),
     meck:expect(features_store_lib, init, ['_', '_'], StoreLibState),
@@ -63,9 +60,6 @@ init_per_testcase(_, Config) ->
 end_per_testcase(_, _Config) ->
     ?assert(meck:validate(features_store_lib)),
     meck:unload(features_store_lib),
-
-    ?assert(meck:validate(timer)),
-    meck:unload(timer),
 
     ?assert(meck:validate(features_count_router)),
     meck:unload(features_count_router),
@@ -163,10 +157,6 @@ ca_test_storage_lib_loading_data(Config) ->
 cb_test_storing_with_storage_lib(Config) ->
     StoreLibState = ?config(store_lib_state, Config),
     Pid = ?config(pid, Config),
-
-    ?assertEqual(?MUT, meck:capture(first, timer, apply_interval, '_', 2)),
-    ?assertEqual(persist, meck:capture(first, timer, apply_interval, '_', 3)),
-    ?assertEqual([Pid], meck:capture(first, timer, apply_interval, '_', 4)),
 
     Key = <<"42">>,
     ?MUT:add(Key, Pid),

--- a/tests/features_counter_persist_manager_SUITE.erl
+++ b/tests/features_counter_persist_manager_SUITE.erl
@@ -1,0 +1,74 @@
+-module(features_counter_persist_manager_SUITE).
+
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+
+-define(MUT, features_counter_persist_manager).
+
+all() -> [{group, all}].
+
+groups() -> [{all, [
+                aa_test_timer_is_setup,
+                ab_test_single_counter_is_persisted
+              ]}
+            ].
+
+init_meck(Config) ->
+    meck:new(features_count_router),
+
+    meck:new(timer, [unstick]),
+    meck:expect(timer, apply_interval, ['_', '_', '_', '_'], {ok, tref}),
+
+    meck:new(features_counter),
+    meck:expect(features_counter, persist, ['_'], ok),
+
+    Config.
+
+init_per_testcase(_, Config) ->
+    NewConfig = init_meck(Config),
+
+    {ok, Pid} = ?MUT:start_link(),
+    [{pid, Pid}|NewConfig].
+
+end_per_testcase(_, _Config) ->
+
+    ?assert(meck:validate(timer)),
+    meck:unload(timer),
+
+    ?assert(meck:validate(features_count_router)),
+    meck:unload(features_count_router),
+
+    ?assert(meck:validate(features_counter)),
+    meck:unload(features_counter),
+    ok.
+
+aa_test_timer_is_setup(Config) ->
+    % Pid = ?config(pid, Config),
+
+    % User = <<"user_id">>,
+    meck:wait(timer, apply_interval, '_', 1000),
+    ?assertEqual(1, meck:num_calls(timer, apply_interval, [60000, ?MUT, persist, []])),
+
+    % ?MUT:add(User, Pid),
+
+    % Num = ?MUT:count(Pid),
+
+    % ?assertEqual(counts(#{count => 1,
+    %                       single_tag_counts => #{},
+    %                       tag_counts => #{[] => 1}}), Num),
+    Config.
+
+ab_test_single_counter_is_persisted(Config) ->
+    CounterPid = self(),
+
+    meck:expect(features_count_router, counter_pids, [], [CounterPid]),
+
+    ?MUT:persist(),
+
+    io:format("Calls ~p~n", [meck:history(features_counter)]),
+    ?assertEqual(1, meck:num_calls(features_counter, persist, [CounterPid])),
+
+    Config.


### PR DESCRIPTION
Instead of having each counter have it's own timer, move to a single
timer for a separate process. This will allow future config options that
manage persistence triggering, to limit things like the rate at which
each counter tries to write