### PR TITLE
metrics: Slow down sending

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -105,6 +105,7 @@ jobs:
 
           cat << EOF > ./app.config
           [{cortex_remote_write, [
+              {interval, 120000},
               {url, "${PROMETHEUS_URL}"},
               {username, "${PROMETHEUS_USERNAME}"},
               {password, "${PROMETHEUS_PASSWORD}"},

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ TEST_DEPS = meck jesse
 TEST_DIR = tests
 DIALYZER_DIRS = --src src tests
 
-dep_cortex_remote_write = git https://github.com/getkimball/cortex_remote_write 0.1.0
+dep_cortex_remote_write = git https://github.com/getkimball/cortex_remote_write 0.1.1
 dep_cowboy = git https://github.com/ninenines/cowboy.git 2.8.0
 dep_cowboy_swagger = hex 2.2.0
 dep_elvis_mk = git https://github.com/inaka/elvis.mk.git 1.0.0


### PR DESCRIPTION
So we conserve the limited resource of metrics sent to Grafana. We don't
really need 15s intervals, 2m will be fine