### PR TITLE
cortex-remote-write: Upgrade to get envvar labels

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -111,7 +111,8 @@ jobs:
               {password, "${PROMETHEUS_PASSWORD}"},
               {default_labels, [
                 {"site", "kimball"},
-                {"cluster", "${CLUSTER}"}
+                {"cluster", "${CLUSTER}"},
+                {"mode", {env, "FEATURES_MODE"}}
               ]}
           ]},
            {prometheus, [{vm_msacc_collector_metrics, []},

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ TEST_DEPS = meck jesse
 TEST_DIR = tests
 DIALYZER_DIRS = --src src tests
 
-dep_cortex_remote_write = git https://github.com/getkimball/cortex_remote_write 0.1.2
+dep_cortex_remote_write = git https://github.com/getkimball/cortex_remote_write 0.1.4
 dep_cowboy = git https://github.com/ninenines/cowboy.git 2.8.0
 dep_cowboy_swagger = hex 2.2.0
 dep_elvis_mk = git https://github.com/inaka/elvis.mk.git 1.0.0


### PR DESCRIPTION
So that I can include core-api vs daemonset in the helm chart, and the
host/pod info in the labels to be able to eventually tell metrics apart