### PR TITLE
metrics: Export counter values to prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,18 @@ Example
 
 ## Metrics
 
+System metrics are available at `/metrics`
+
+Some important ones:
+
 * `kimball_counters` - The number of counters registered with the router. Equivalent to the number of events tracked.
 * `kimball_persist_counters_managed` - The number of counters the persistence manager triggered in the last run. Should track, but lag, `kimball_counters`.
+
+Metrics for each counter are available at `/metrics/counters`
+
+* `kimball_counter` - Event counters
+
+* `kimball_counter_weekly` - Per week counters if `date_cohort => weekly` is set.
 
 ## Releasing
 

--- a/tests/test_utils.erl
+++ b/tests/test_utils.erl
@@ -20,6 +20,7 @@ meck_load_prometheus() ->
     ok = meck:new(prometheus_gauge),
     meck:expect(prometheus_gauge, declare, ['_'], ok),
     meck:expect(prometheus_gauge, set, ['_', '_'], ok),
+    meck:expect(prometheus_gauge, set, ['_', '_', '_', '_'], ok),
 
     ok = meck:new(prometheus_summary),
     meck:expect(prometheus_summary, declare, ['_'], ok),


### PR DESCRIPTION
So that they can be tracked over time externally

These are available as a separate regsitry, over HTTP visible at
/metrics/counters. These won't be pushed with remote_write as that only
uses the default registry