### PR TITLE
router: Only checks keys for named counters

### DIFF
--- a/src/features_counter_id.erl
+++ b/src/features_counter_id.erl
@@ -7,6 +7,7 @@
          create/3,
          name/1,
          pattern_matcher_name/1,
+         pattern_matcher_type/1,
          to_file_path/1,
          to_full_name/1,
          to_prometheus_label_keys/1,
@@ -36,6 +37,9 @@ name(#id{name=Name}) ->
 
 pattern_matcher_name(Name) ->
     #id{name=Name, type='_', data='_'}.
+
+pattern_matcher_type(Type) ->
+    #id{name='_', type=Type, data='_'}.
 
 type(#id{type=Type}) ->
     Type.

--- a/tests/features_count_router_SUITE.erl
+++ b/tests/features_count_router_SUITE.erl
@@ -460,7 +460,7 @@ ea_test_triggering_a_goal(Config) ->
     Counts = ?MUT:counts(),
 
     io:format("Adds ~p~n", [meck:history(?COUNTER_MOD)]),
-    ExpectedEvents = lists:sort([<<"global_counter">>, NonGoalFeature]),
+    ExpectedEvents = lists:sort([NonGoalFeature]),
     ?assertEqual(User, meck:capture(first, ?COUNTER_MOD, add, ['_', '_', '_', GoalCounterPid], 1)),
     ?assertEqual(ExpectedEvents, lists:sort(meck:capture(first, ?COUNTER_MOD, add, ['_', '_', '_', GoalCounterPid], 2))),
 
@@ -523,7 +523,7 @@ eb_test_triggering_a_goal_registered_after_goal_added(Config) ->
 
     Counts = ?MUT:counts(),
 
-    ExpectedEvents = lists:sort([<<"global_counter">>, NonGoalFeature]),
+    ExpectedEvents = lists:sort([NonGoalFeature]),
     ?assertEqual(User, meck:capture(first, ?COUNTER_MOD, add, ['_', '_', '_'], 1)),
     ?assertEqual(ExpectedEvents, lists:sort(meck:capture(first, ?COUNTER_MOD, add, ['_', '_', '_', '_'], 2))),
     ?assertEqual(GoalCounterPid, meck:capture(first, ?COUNTER_MOD, add, ['_', '_', '_', '_'], 4)),


### PR DESCRIPTION
Filter counters by id type before checking the counters for a key. This
removes the global_counter in the current case, as well as any weekly
counters. The result is that fewer counters are hit per new goal added
(nice to reduce points of constraint).

This is also preparation for adding predictions, knowing that the
counters are named events will be helpful in the abscence of type
information stored with the goal. We can say "this is only named events"
instead of trying to figure it out later. Also avoids having
records/another format that gets stored with a goal.