### PR TITLE
github: Use tagged deploy-actions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -76,7 +76,7 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v1
 
     - name: Helm install
-      uses: getkimball/deploy-action@trunk
+      uses: getkimball/deploy-action@1.2
       env:
         DOCKER_TAG: ${{ needs.build_docker.outputs.docker_tag }}
         ECR_REPOSITORY: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.DOCKER_REPOSITORY }}


### PR DESCRIPTION
To see if it uses a cached version from Github. Updating this will be
more annoying, but faster overall if the cache is used