### PR TITLE
svelte: Put CSS in the right place

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ export default {
             // we'll extract any component CSS out into
             // a separate file - better for performance
             css: css => {
-                css.write('priv/public/build/bundle.css');
+                css.write('bundle.css');
             }
         }),
 


### PR DESCRIPTION
This line was previously  putting this doubly as deep due to the root
being set elsewhere.