### PR TITLE
swagger: Return actual body

### DIFF
--- a/src/swagger_specified_handler.erl
+++ b/src/swagger_specified_handler.erl
@@ -450,7 +450,7 @@ body_from_request(Req = #{has_body := true}, Spec) ->
         end,
 
     {ok, Body, Req1} = cowboy_req:read_body(Req),
-    Data = features_json:decode_or_throw(Body, {invalid_json, post_body}),
+    Data = features_json:decode_or_throw(Body, {invalid_json, Body}),
     #{schema := Schema} = ContentSpec,
     ParsedData = match_schema(Schema, Data),
 

--- a/tests/features_handler_v0_feature_specs_test.erl
+++ b/tests/features_handler_v0_feature_specs_test.erl
@@ -56,7 +56,7 @@ create_feature_invalid_json_test() ->
     Expected = #{
         <<"error">> => #{
             <<"what">> => Msg,
-            <<"object">> => <<"post_body">>
+            <<"object">> => <<"{:not valid json">>
         }
     },
     http_post(PostReq, 400, Expected),


### PR DESCRIPTION
Return the body during an error where JSON is invalid. Otherwise this
returns an unhelpful "post_body" atom.