### PR TITLE
Naive Bayes events -> goals API

### DIFF
--- a/src/features_bayesian_predictor.erl
+++ b/src/features_bayesian_predictor.erl
@@ -11,33 +11,60 @@
 bayes(BGivenA, A, B) ->
     (BGivenA * A) / B.
 
+% Naive bayes for multiple events
 for_events(_Namespace, []) ->
     #{};
 for_events(Namespace, Events) ->
-    GlobalPredictions = for_goal_counts(Namespace),
+    CountMap = features_count_router:count_map(Namespace),
+    GoalCounts = goal_counts_from_count_map(CountMap),
 
-    GlobalFun = fun(FoldGoal, FoldPredictions, GoalAccIn) ->
-        % Iterating all predictions, maps goals => #{event => val}
-        PredictionFun = fun(PredictionEvent, PredictionVal, PredictionAccIn) ->
-            % Iterating #{event => val} map, accumulating the #{goal => val} so they can be merged later
-            case lists:member(PredictionEvent, Events) of
-                true ->
-                    PreviousPrediction = maps:get(FoldGoal, PredictionAccIn, 1),
-                    PredictionAccIn#{FoldGoal => PreviousPrediction * PredictionVal};
-                false ->
-                    PredictionAccIn
-            end
+    GlobalFun = fun(FoldGoalID, #{count := GoalCount, single_tag_counts := GoalSTC}, GoalAccIn) ->
+        GoalName = features_counter_id:name(FoldGoalID),
+        EventCounterFun = fun(Event) ->
+            GoalEventCount = maps:get(Event, GoalSTC, 0),
+            EventID = features_counter_id:create(Namespace, Event, named),
+            EventCount =
+                case maps:is_key(EventID, CountMap) of
+                    true ->
+                        #{EventID := #{count := EventCountMatch}} = CountMap,
+                        EventCountMatch;
+                    false ->
+                        throw({unknown_event, Event})
+                end,
+
+            EventNotGoalCount = EventCount - GoalEventCount,
+
+            YesEventChange = GoalEventCount / GoalCount,
+            NoEventChange = EventNotGoalCount / GoalCount,
+
+            {YesEventChange, NoEventChange}
         end,
-        GoalPredictionMap = maps:fold(PredictionFun, #{}, FoldPredictions),
-        maps:merge(GoalAccIn, GoalPredictionMap)
+
+        % Don't run if goal is part of events, we'll skip them for now
+        case lists:member(GoalName, Events) of
+            true ->
+                Note = <<"Submitted events included this goal, no prediction made">>,
+                GoalAccIn#{GoalName => #{note => Note}};
+            false ->
+                EventCounts = lists:map(EventCounterFun, Events),
+
+                {EventSumYes, EventSumNo} = lists:foldl(
+                    fun({Py, Pn}, {AccY, AccN}) -> {Py * AccY, Pn * AccN} end,
+                    {1, 1},
+                    EventCounts
+                ),
+
+                GoalAccIn#{GoalName => #{yes => EventSumYes, no => EventSumNo}}
+        end
     end,
-    GlobalGoalPredictions = maps:fold(GlobalFun, #{}, GlobalPredictions),
+    GlobalGoalPredictions = maps:fold(GlobalFun, #{}, GoalCounts),
 
     GlobalGoalPredictions.
 
+% Bayes calculation
 for_goal_counts(Namespace) ->
     CountMap = features_count_router:count_map(Namespace),
-    GoalCounts = maps:filter(fun filter_goals_with_tagged_events/2, CountMap),
+    GoalCounts = goal_counts_from_count_map(CountMap),
     GlobalCounterId = features_counter_id:global_counter_id(Namespace),
 
     ?LOG_DEBUG(#{
@@ -77,6 +104,9 @@ bayes_for_counts(GlobalCount, GoalCount, TagCount, GoalTagCount) ->
     B = TagCount / GlobalCount,
 
     bayes(BGivenA, A, B).
+
+goal_counts_from_count_map(CountMap) ->
+    maps:filter(fun filter_goals_with_tagged_events/2, CountMap).
 
 filter_goals_with_tagged_events(_ID, #{single_tag_counts := Counts}) when map_size(Counts) == 0 ->
     false;

--- a/src/features_handler_v0_predictions.erl
+++ b/src/features_handler_v0_predictions.erl
@@ -92,24 +92,36 @@ handle_req(
 ) ->
     Namespace = proplists:get_value(namespace, Params),
     Events = proplists:get_value(event, Params),
-    RenderedPredictions =
-        case Events of
-            [] ->
-                Predictions = features_bayesian_predictor:for_goal_counts(Namespace),
-                RP = maps:map(
-                    fun render_bayes_as_predictions/2,
-                    Predictions
-                ),
-                RP;
-            Else ->
-                Predictions = features_bayesian_predictor:for_events(Namespace, Else),
-                Predictions
+    Resp =
+        try get_predictions(Namespace, Events) of
+            Predictions ->
+                Data = #{<<"goals">> => Predictions},
+                {Req, 200, Data, State}
+        catch
+            {unknown_event, Event} ->
+                Response = #{
+                    error => #{
+                        what => <<"Event is not known in this namespace">>,
+                        event => Event
+                    }
+                },
+                {Req, 400, Response, State}
         end,
-    Data = #{<<"goals">> => RenderedPredictions},
-    {Req, 200, Data, State}.
+    Resp.
 
 post_req(_Response, _State) ->
     ok.
+
+get_predictions(Namespace, []) ->
+    Predictions = features_bayesian_predictor:for_goal_counts(Namespace),
+    RP = maps:map(
+        fun render_bayes_as_predictions/2,
+        Predictions
+    ),
+    RP;
+get_predictions(Namespace, Events) ->
+    Predictions = features_bayesian_predictor:for_events(Namespace, Events),
+    Predictions.
 
 render_bayes_as_predictions(_K, V) ->
     RenderedEvents = maps:map(fun render_events_to_bayes_maps/2, V),


### PR DESCRIPTION
Use a naive bayes algorithm to return a prediction of what goals are most likely for a combination of events. 