### PR TITLE
config: Add check for invalid date_cohort

### DIFF
--- a/src/features_counter_config.erl
+++ b/src/features_counter_config.erl
@@ -48,6 +48,12 @@ validate_individual_config(Config) ->
 
 init_filter(undefined) ->
     default_filter();
+init_filter(Config = #{date_cohort := weekly}) ->
+    NewConfig = maps:remove(date_cohort, Config),
+    init_filter(NewConfig);
+init_filter(Config = #{date_cohort := _DateCohort}) ->
+    Msg = "date_cohort must be omitted or `weekly`.",
+    throw({invalid_bloom_filter_config, Config, Msg});
 init_filter(#{type := bloom_scalable, size := Size, error_probability := EP}) ->
     etbloom:sbf(Size, EP);
 init_filter(#{type := bloom_fixed_size, size := Size, error_probability := EP}) ->

--- a/tests/features_counter_config_test.erl
+++ b/tests/features_counter_config_test.erl
@@ -136,8 +136,10 @@ validate_config_test_() ->
     {foreach, fun load/0, fun unload/1, [
         fun validate_empty_config/0,
         fun validate_valid_config/0,
+        fun validate_valid_date_cohort_config/0,
         fun validate_config_missing_keys/0,
-        fun validate_config_invalid_filter/0
+        fun validate_config_invalid_filter/0,
+        fun validate_config_invalid_date_cohort_filter/0
     ]}.
 
 validate_empty_config() ->
@@ -147,6 +149,17 @@ validate_empty_config() ->
 validate_valid_config() ->
     Config = #{
         type => bloom_fixed_size,
+        pattern => ".*",
+        size => 10000
+    },
+    set_filter_initial_config([Config]),
+
+    ?assertEqual(ok, ?MUT:validate_config()).
+
+validate_valid_date_cohort_config() ->
+    Config = #{
+        type => bloom_fixed_size,
+        date_cohort => weekly,
         pattern => ".*",
         size => 10000
     },
@@ -175,7 +188,19 @@ validate_config_invalid_filter() ->
     Error =
         {invalid_bloom_filter_config, Config,
             "Config is missing required keys or size/error proability does not work"},
+    ?assertThrow(Error, ?MUT:validate_config()).
 
+validate_config_invalid_date_cohort_filter() ->
+    Config = #{
+        type => fixed,
+        date_cohort => invalid_type,
+        pattern => ".*",
+        size => 10
+    },
+    set_filter_initial_config([Config]),
+
+    Error =
+        {invalid_bloom_filter_config, Config, "date_cohort must be omitted or `weekly`."},
     ?assertThrow(Error, ?MUT:validate_config()).
 
 set_filter_initial_config(Config) ->


### PR DESCRIPTION
Previously an invalid date_cohort config would fail once events were added. This is better to fail sooner when the config is invalid. 