### PR TITLE
Dockerfile: Set default log level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN mv /app/src/_rel/features_release/features_*.tar.gz /app.tar.gz
 
 FROM debian:buster
 
+ENV LOG_LEVEL=info
+
 RUN apt-get update && apt-get install -y openssl && apt-get clean
 
 COPY --from=builder /app.tar.gz /app.tar.gz


### PR DESCRIPTION
The erl release wants LOG_LEVEL defined or the syntax for the config
file will be wrong (a placeholder is left in). Add a default to avoid
this