### PR TITLE
dev: Fix priv dir lookup for cowboy data

### DIFF
--- a/sys.config
+++ b/sys.config
@@ -7,6 +7,7 @@
   ]}
 ]},
  {features, [
-  {file_store_path, "features.json"}
+  {file_store_path, "features.json"},
+  {local_dev, true}
 ]},
 "local"].


### PR DESCRIPTION
The priv_dir function relies on filesystem dir naming to match the
application names. If the dir doesn't match this doesn't work.

The release for this handles things correctly.

After renaming the project features -> api this problem surfaced. Fix
this so we don't rely on the dir naming to match the app name.