### PR TITLE
auth: Exclude ok handler

### DIFF
--- a/src/cb_auth_simple_header.erl
+++ b/src/cb_auth_simple_header.erl
@@ -2,22 +2,41 @@
 
 -export([execute/2]).
 
-execute(Req, Env=#{cb_auth := #{auth_tokens := Tokens,
-                                unauth_handler := UnauthHandler}}) ->
+execute(
+    Req,
+    Env = #{
+        cb_auth := #{
+            auth_tokens := Tokens,
+            unauth_handler := UnauthHandler
+        },
+        handler := Handler
+    }
+) ->
+    #{cb_auth := CBAuth} = Env,
+
+    ExcludedHandlers = maps:get(exclude_handlers, CBAuth, []),
     AuthHeader = cowboy_req:header(<<"Authorization">>, Req),
     ErrorEnv = Env#{handler => UnauthHandler},
 
-    NewEnv = case token_for_authheader(AuthHeader) of
-        undefined -> ErrorEnv;
-        TokenValue -> case lists:member(TokenValue, Tokens) of
-            true -> Env;
-            false -> ErrorEnv
-        end
-    end,
+    NewEnv =
+        case lists:member(Handler, ExcludedHandlers) of
+            true ->
+                Env;
+            false ->
+                case token_for_authheader(AuthHeader) of
+                    undefined ->
+                        ErrorEnv;
+                    TokenValue ->
+                        case lists:member(TokenValue, Tokens) of
+                            true -> Env;
+                            false -> ErrorEnv
+                        end
+                end
+        end,
     {ok, Req, NewEnv}.
 
 token_for_authheader(undefined) ->
     undefined;
-token_for_authheader(<< _Bearer:7/binary, Token/binary >>) ->
+token_for_authheader(<<_Bearer:7/binary, Token/binary>>) ->
     % 7 bytes for "bearer "
     Token.

--- a/src/features_app.erl
+++ b/src/features_app.erl
@@ -48,19 +48,23 @@ start(_Type, _Args) ->
 
     Dispatch = trails:single_host_compile(AllRoutes),
 
-    Middlewares = case application:get_env(features, api_auth, enable) of
-       enable ->  [cowboy_router, cb_auth_simple_header, cowboy_handler];
-       disable ->  [cowboy_router, cowboy_handler]
-    end,
+    Middlewares =
+        case application:get_env(features, api_auth, enable) of
+            enable -> [cowboy_router, cb_auth_simple_header, cowboy_handler];
+            disable -> [cowboy_router, cowboy_handler]
+        end,
 
     CBAuthOpts = #{
         auth_tokens => application:get_env(features, api_auth_tokens, []),
+        exclude_handlers => [features_handler_ok],
         unauth_handler => features_handler_unauthorized
     },
 
     HTTPOpts = #{
-        env => #{dispatch => Dispatch,
-                 cb_auth => CBAuthOpts},
+        env => #{
+            dispatch => Dispatch,
+            cb_auth => CBAuthOpts
+        },
         metrics_callback => fun prometheus_cowboy2_instrumenter:observe/1,
         middlewares => Middlewares,
         stream_handlers => [cowboy_metrics_h, cowboy_stream_h]

--- a/tests/cb_auth_simple_header_test.erl
+++ b/tests/cb_auth_simple_header_test.erl
@@ -15,21 +15,26 @@ bearer_auth_test_() ->
     {foreach, fun load/0, fun unload/1, [
         fun bearer/0,
         fun bearer_no_header/0,
-        fun bearer_no_tokens/0
+        fun bearer_no_tokens/0,
+        fun exclude_handler/0
     ]}.
 
 bearer() ->
     Token = <<"foo">>,
     Headers = #{
-        <<"Authorization">> => << <<"Bearer ">>/binary, Token/binary >>
+        <<"Authorization">> => <<<<"Bearer ">>/binary, Token/binary>>
     },
     Req = ?CTH:req(<<"GET">>, #{headers => Headers}),
 
-    Env = #{cb_auth => #{auth_tokens => [Token],
-                         unauth_handler => unauth_handler}},
+    Env = #{
+        cb_auth => #{
+            auth_tokens => [Token],
+            unauth_handler => unauth_handler
+        },
+        handler => test_handler
+    },
 
     MiddlewareResp = ?MUT:execute(Req, Env),
-
 
     ?assertEqual({ok, Req, Env}, MiddlewareResp).
 
@@ -38,28 +43,58 @@ bearer_no_header() ->
     Headers = #{},
     Req = ?CTH:req(<<"GET">>, #{headers => Headers}),
 
-    Env = #{cb_auth => #{auth_tokens => [Token],
-                         unauth_handler => unauth_handler}},
+    Env = #{
+        cb_auth => #{
+            auth_tokens => [Token],
+            unauth_handler => unauth_handler
+        },
+        handler => test_handler
+    },
 
     MiddlewareResp = ?MUT:execute(Req, Env),
 
     ExpectedEnv = Env#{handler => unauth_handler},
-
 
     ?assertEqual({ok, Req, ExpectedEnv}, MiddlewareResp).
 
 bearer_no_tokens() ->
     Token = <<"foo">>,
     Headers = #{
-        <<"Authorization">> => << <<"Bearer ">>/binary, Token/binary >>
+        <<"Authorization">> => <<<<"Bearer ">>/binary, Token/binary>>
     },
     Req = ?CTH:req(<<"GET">>, #{headers => Headers}),
 
-    Env = #{cb_auth => #{auth_tokens => [],
-                         unauth_handler => unauth_handler}},
+    Env = #{
+        cb_auth => #{
+            auth_tokens => [],
+            unauth_handler => unauth_handler
+        },
+        handler => test_handler
+    },
 
     MiddlewareResp = ?MUT:execute(Req, Env),
 
     ExpectedEnv = Env#{handler => unauth_handler},
+
+    ?assertEqual({ok, Req, ExpectedEnv}, MiddlewareResp).
+
+exclude_handler() ->
+    Token = <<"foo">>,
+    Headers = #{},
+    Req = ?CTH:req(<<"GET">>, #{headers => Headers}),
+    Handler = test_handler,
+
+    Env = #{
+        cb_auth => #{
+            auth_tokens => [Token],
+            exclude_handlers => [Handler],
+            unauth_handler => unauth_handler
+        },
+        handler => Handler
+    },
+
+    MiddlewareResp = ?MUT:execute(Req, Env),
+
+    ExpectedEnv = Env#{handler => Handler},
 
     ?assertEqual({ok, Req, ExpectedEnv}, MiddlewareResp).


### PR DESCRIPTION
So that enabling auth doesn't break kubernetes healthchecks. If there is
some constant header put through, the lack of authorization for handler
routes means the healthcheck credentials could be use for any operation